### PR TITLE
build(server): add from CNCF for local development

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+const req = require('https').request('https://raw.githubusercontent.com/cncf/landscapeapp/master/netlify/server.js', function(res) {
+    process.on('SIGINT', function() {
+        console.log("Caught interrupt signal. Exiting...");
+        process.exit();
+    });
+    let script = '';
+    res.on('data', (chunk) => script += chunk);
+    res.on('end', () => eval(script));
+});
+req.end();


### PR DESCRIPTION
As suggested by @AndreyKozlov1984 this adds the `server.js` file from the CNCF landscape: https://github.com/cncf/landscape/blob/master/server.js

This allows local development by simply running `node server.js` This will build the landscape and start a local sever at http://127.0.0.1:8001/